### PR TITLE
Support nested field filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist/
 *.egg-info/
 build/
 .tox/
+VENV/
+.idea/

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 readme = open('README.rst').read()
 
 setup(name='drf_dynamic_fields',
-      version='0.2.0',
+      version='0.3.0-osprey',
       description='Dynamically return subset of Django REST Framework serializer fields',
       author='Danilo Bargen',
       author_email='mail@dbrgn.ch',

--- a/tests/models.py
+++ b/tests/models.py
@@ -11,7 +11,7 @@ class Pet(models.Model):
 
 class Teacher(models.Model):
     name = models.CharField(max_length=50, blank=True, null=True)
-    class_pet = models.ForeignKey(Pet, models.SET_NULL, blank=True, null=True)
+    class_pet = models.ForeignKey(Pet, blank=True, null=True)
 
 
 class School(models.Model):

--- a/tests/models.py
+++ b/tests/models.py
@@ -4,8 +4,14 @@ Some models for the tests. We are modelling a school.
 from django.db import models
 
 
+class Pet(models.Model):
+    name = models.CharField(max_length=50)
+    age = models.IntegerField()
+
+
 class Teacher(models.Model):
-    """No fields, no fun."""
+    name = models.CharField(max_length=50, blank=True, null=True)
+    class_pet = models.ForeignKey(Pet, models.SET_NULL, blank=True, null=True)
 
 
 class School(models.Model):

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -5,7 +5,13 @@ from rest_framework import serializers
 
 from drf_dynamic_fields import DynamicFieldsMixin
 
-from .models import Teacher, School
+from .models import Teacher, School, Pet
+
+
+class PetSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    class Meta:
+        model = Pet
+        fields = ('id', 'name', 'age')
 
 
 class TeacherSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
@@ -15,10 +21,11 @@ class TeacherSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     """
 
     request_info = serializers.SerializerMethodField()
+    class_pet = PetSerializer()
 
     class Meta:
         model = Teacher
-        fields = ('id', 'request_info')
+        fields = ('id', 'name', 'request_info', 'class_pet',)
 
     def get_request_info(self, teacher):
         """


### PR DESCRIPTION
Changes to support nested field filtering as part of OD-5185.  These changes are already tagged as `0.3.0-osprey`, and hopefully this whole repo is temporary, but we should get these merged to master in case we need to make additional modifications in the future so people start from the correct code.